### PR TITLE
Due to adapt BCM2711, authorize access under /sys thus, BCM2711 can u…

### DIFF
--- a/qr-monitoring-function/src/requirements.txt
+++ b/qr-monitoring-function/src/requirements.txt
@@ -1,1 +1,1 @@
-pynput
+pynput==1.6.8

--- a/template.yml
+++ b/template.yml
@@ -280,6 +280,7 @@ Resources:
             Timeout: 2000
             EncodingType: json
             Environment:
+              AccessSysfs: True
               Variables:
                 STACK_NAME:
                   Ref: "AWS::StackName"
@@ -296,6 +297,7 @@ Resources:
             Timeout: 2000
             EncodingType: json
             Environment:
+              AccessSysfs: True
               Variables:
                 STACK_NAME:
                   Ref: "AWS::StackName"
@@ -354,6 +356,7 @@ Resources:
             Timeout: 2000
             EncodingType: json
             Environment:
+              AccessSysfs: True
               Variables:
                 STACK_NAME:
                   Ref: "AWS::StackName"


### PR DESCRIPTION
…se GPIO

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
